### PR TITLE
Add GNOME 44 Support

### DIFF
--- a/fullscreen-notifications@sorrow.about.alice.pm.me/metadata.json
+++ b/fullscreen-notifications@sorrow.about.alice.pm.me/metadata.json
@@ -2,7 +2,7 @@
   "name": "Fullscreen Notifications",
   "description": "Enables all notifications in fullscreen mode",
   "uuid": "fullscreen-notifications@sorrow.about.alice.pm.me",
-  "shell-version": ["41", "42", "43"],
+  "shell-version": ["41", "42", "43", "44"],
   "version": 7,
   "url": "https://github.com/soal/gnome-shell-extension-fullscreen-notifications"
 }


### PR DESCRIPTION
### Update metadata.json

This fixes #7 - [Feature Request] Add GNOME 44 Support.

Editing `metadata.json` fixes the compatibility issue with GNOME 44. `extension.js` works completely fine on GNOME 44 so only metadata needs to be changed.

_Tested on Fedora 38 running GNOME 44._